### PR TITLE
fix #12 ActionButton positioning

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -89,7 +89,7 @@ class ActionButton extends Component {
   //////////////////////
 
   getContainerStyles() {
-    if (this.state.active) return [ styles.overlay, { height : sH, width : sW } ]
+    if (this.state.active) return [ styles.overlay ]
     return [ styles.actionBarPos, this.getButtonSize(), this.getOffsetXY() ]
   }
 


### PR DESCRIPTION
Any particular reason to set the height & width of the container explicitly ? Just setting absolute values (e.g: `top: 0`) should be enough.

I think `Dimensions.get('window').height` gives you the height of the whole window & not just the view available to the app, which is why when the state is active, the height of the container gets a bit larger and overflows.

This should also fix the issue on landscape mode here: https://github.com/mastermoo/react-native-action-button/issues/12