### PR TITLE
Rotate Custom Icon on ActionButton

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -15,16 +15,9 @@ export default class ActionButton extends Component {
 
     this.state = {
       active: props.active,
-      type: props.type,
-      bgColor: props.bgColor,
-      buttonColor: props.buttonColor,
-      buttonTextColor: props.buttonTextColor,
-      spacing: props.spacing,
       btnOutRange: props.btnOutRange || props.buttonColor || 'rgba(0,0,0,1)',
       btnOutRangeTxt: props.btnOutRangeTxt || props.buttonTextColor || 'rgba(255,255,255,1)',
-      outRangeScale: props.outRangeScale,
-      anim: new Animated.Value(this.props.active ? 1 : 0),
-      backdrop: props.backdrop
+      anim: new Animated.Value(props.active ? 1 : 0),
     }
 
     this.timeout = null;
@@ -35,10 +28,16 @@ export default class ActionButton extends Component {
     clearTimeout(this.timeout);
   }
 
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      ...nextProps
+    });
+  }
+
   setPositionAndSizeByType() {
     let position, offsetX, offsetY, size;
 
-    if (this.state.type == 'tab') {
+    if (this.props.type == 'tab') {
       position = 'center',
       offsetX  = 10,
       offsetY  = 4,
@@ -100,7 +99,7 @@ export default class ActionButton extends Component {
     return (
       <View pointerEvents="box-none" style={styles.overlay}>
         <Animated.View pointerEvents="none" style={[styles.overlay, {
-          backgroundColor: this.state.bgColor,
+          backgroundColor: this.props.bgColor,
           opacity: this.state.anim
         }]}>
           {this.props.backdrop}
@@ -130,12 +129,12 @@ export default class ActionButton extends Component {
               borderRadius: this.state.size / 2,
               backgroundColor: this.state.anim.interpolate({
                 inputRange: [0, 1],
-                outputRange: [this.state.buttonColor, this.state.btnOutRange]
+                outputRange: [this.props.buttonColor, this.state.btnOutRange]
               }),
               transform: [{
                   scale: this.state.anim.interpolate({
                     inputRange: [0, 1],
-                    outputRange: [1, this.state.outRangeScale]
+                    outputRange: [1, this.props.outRangeScale]
                   }),
                 }, {
                   rotate: this.state.anim.interpolate({
@@ -158,7 +157,7 @@ export default class ActionButton extends Component {
       <Animated.Text style={[styles.btnText, {
         color: this.state.anim.interpolate({
           inputRange: [0, 1],
-          outputRange: [this.state.buttonTextColor, this.state.btnOutRangeTxt]
+          outputRange: [this.props.buttonTextColor, this.state.btnOutRangeTxt]
         })
       }]}>
         +
@@ -185,7 +184,7 @@ export default class ActionButton extends Component {
               <ActionButtonItem
                 key={index}
                 position={this.state.position}
-                spacing={this.state.spacing}
+                spacing={this.props.spacing}
                 anim={this.state.anim}
                 size={this.state.size}
                 btnColor={this.state.btnOutRange}

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -139,7 +139,7 @@ export default class ActionButton extends Component {
                 }, {
                   rotate: this.state.anim.interpolate({
                     inputRange: [0, 1],
-                    outputRange: ['0deg', this.props.icon ? '0deg' : '135deg']
+                    outputRange: ['0deg', this.props.degrees + 'deg']
                   })
                 }],
             }]}>
@@ -253,7 +253,8 @@ ActionButton.propTypes = {
   backdrop: PropTypes.oneOfType([
     PropTypes.bool,
     PropTypes.object
-  ])
+]),
+  degrees: PropTypes.number
 };
 
 ActionButton.defaultProps = {
@@ -266,7 +267,8 @@ ActionButton.defaultProps = {
   outRangeScale: 1,
   autoInactive: true,
   onPress: () => {},
-  backdrop: false
+  backdrop: false,
+  degrees: 135
 };
 
 const styles = StyleSheet.create({

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Also this example uses `react-native-vector-icons` for the button Icons.
 | onLongPress   | function      | null                | fires, when ActionButton is long pressed
 | icon          | Component     | +                   | Custom component for ActionButton Icon
 | backdrop      | Component     | false               | Custom component for use as Backdrop (i.e. [BlurView](https://github.com/react-native-fellowship/react-native-blur#blur-view), [VibrancyView](https://github.com/react-native-fellowship/react-native-blur#vibrancy-view))
+| degrees       | number        | 135                 | degrees to rotate icon
 
 ##### ActionButton.Item:
 | Property      | Type          | Default             | Description |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-action-button",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "customizable multi-action-button component for react-native",
   "main": "ActionButton.js",
   "scripts": {


### PR DESCRIPTION
Right now if you set a custom component as the icon on ActionButton.js, it will not rotate when clicked.

I added a prop "degrees" which is now used to specify how far to turn the icon, and will animate custom icons.