### PR TITLE
update for latest ionicons set

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ class App extends Component {
         {/*Rest of App come ABOVE the action button component!*/}
         <ActionButton buttonColor="rgba(231,76,60,1)">
           <ActionButton.Item buttonColor='#9b59b6' title="New Task" onPress={() => console.log("notes tapped!")}>
-            <Icon name="android-create" style={styles.actionButtonIcon} />
+            <Icon name="md-create" style={styles.actionButtonIcon} />
           </ActionButton.Item>
           <ActionButton.Item buttonColor='#3498db' title="Notifications" onPress={() => {}}>
-            <Icon name="android-notifications-none" style={styles.actionButtonIcon} />
+            <Icon name="md-notifications-off" style={styles.actionButtonIcon} />
           </ActionButton.Item>
           <ActionButton.Item buttonColor='#1abc9c' title="All Tasks" onPress={() => {}}>
-            <Icon name="android-done-all" style={styles.actionButtonIcon} />
+            <Icon name="md-done-all" style={styles.actionButtonIcon} />
           </ActionButton.Item>
         </ActionButton>
       </View>

--- a/example/Basic/index.android.js
+++ b/example/Basic/index.android.js
@@ -22,13 +22,13 @@ class Basic extends Component {
         </Text>
         <ActionButton buttonColor="rgba(231,76,60,1)">
           <ActionButton.Item buttonColor='#9b59b6' title="New Task" onPress={() => console.log("notes tapped!")}>
-            <Icon name="android-create" style={styles.actionButtonIcon} />
+            <Icon name="me-create" style={styles.actionButtonIcon} />
           </ActionButton.Item>
           <ActionButton.Item buttonColor='#3498db' title="Notifications" onPress={() => {}}>
-            <Icon name="android-notifications-none" style={styles.actionButtonIcon} />
+            <Icon name="me-notifications-off" style={styles.actionButtonIcon} />
           </ActionButton.Item>
           <ActionButton.Item buttonColor='#1abc9c' title="All Tasks" onPress={() => {}}>
-            <Icon name="android-done-all" style={styles.actionButtonIcon} />
+            <Icon name="md-done-all" style={styles.actionButtonIcon} />
           </ActionButton.Item>
         </ActionButton>
       </View>


### PR DESCRIPTION
The latest [commit](https://github.com/oblador/react-native-vector-icons/commit/e6d14e16128463be18ca9eeb30c5dabcd4e75612#diff-c15b995c6e1108dbee322530ee81b8f4) to the Iconicon.js file in the react-native-vector-icons removes the `android-` prefix in favor of `md-` prefix. This pull request updates the README and the example to match