### PR TITLE
Fixed button shadow on Android 5+

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -310,6 +310,8 @@ const styles = StyleSheet.create({
     position: 'relative',
   },
   btnShadow: {
+    elevation: 6,
+    marginBottom: 12,
     shadowOpacity: 0.3,
     shadowOffset: {
       width: 0, height: 1,

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -114,6 +114,8 @@ const styles = StyleSheet.create({
     },
     shadowColor: '#444',
     shadowRadius: 1,
+    elevation: 6,
+    marginBottom: 12,
   },
   actionTextView: {
     position: 'absolute',


### PR DESCRIPTION
I fixed missing button shadow on Android 5+. It uses elevation style available in React Native. I had to add bottom margin to make it visible. The bottom margin might brake the look on iOS, I haven't tested it on iOS. Somebody, please, test it on iOS :) and tell me if it's ok... But I think it should be allright.