### PR TITLE
Removed top padding from action button item. The padding caused the i…

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -119,7 +119,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     flexDirection: 'row',
-    paddingTop: 2,
     shadowOpacity: 0.3,
     shadowOffset: {
       width: 0, height: 1,


### PR DESCRIPTION
If you look closely enough at the button items, they get cropped from the bottom a little bit. Looks like removing the paddingTop fixes it.