### PR TITLE
Button shadow gets cropped on left and right 

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -55,7 +55,6 @@ export default class ActionButton extends Component {
 
   getOffsetXY() {
     return {
-      paddingHorizontal: this.props.offsetX,
       paddingBottom: this.props.offsetY
     };
   }
@@ -115,6 +114,7 @@ export default class ActionButton extends Component {
         shadowColor: '#444',
         shadowRadius: 1,
         elevation: 6,
+        marginBottom: shadowHeight,
         backgroundColor: this.anim.interpolate({
           inputRange: [0, 1],
           outputRange: [this.props.buttonColor, buttonColorMax]
@@ -134,18 +134,21 @@ export default class ActionButton extends Component {
     ];
 
     return (
-      <View style={this.getActionButtonStyles()}>
+      <View style={[this.getActionButtonStyles(), { width: this.props.size + 25, paddingLeft: this.props.offsetX }]}>
         <TouchableOpacity
+          style={{ right: this.props.offsetX }}
           activeOpacity={0.85}
           onLongPress={this.props.onLongPress}
           onPress={() => {
             this.props.onPress()
             if (this.props.children) this.animateButton()
           }}>
+          <View style={{ paddingRight: this.props.offsetX  }}>
           <Animated.View
             style={animatedViewStyle}>
             {this._renderButtonIcon()}
           </Animated.View>
+          </View>
         </TouchableOpacity>
       </View>
     );
@@ -281,8 +284,8 @@ ActionButton.defaultProps = {
   backdrop: false,
   degrees: 135,
   position: 'right',
-  offsetX: 30,
-  offsetY: 30,
+  offsetX: 16,
+  offsetY: 6,
   size: 56,
   verticalOrientation: 'up',
 };

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -56,7 +56,7 @@ export default class ActionButtonItem extends Component {
         ]}
       >
         <TouchableOpacity
-          style={{ flex:1 }}
+          style={{ width: this.props.size + 35, paddingLeft: 10, flex:1 }}
           activeOpacity={this.props.activeOpacity || 0.85}
           onPress={this.props.onPress}
         >
@@ -94,7 +94,7 @@ export default class ActionButtonItem extends Component {
     let offsetTop = this.props.size >= 28 ? (this.props.size / 2) - 14 : 0;
 
     let positionStyles = {
-      right: this.props.size + this.state.spaceBetween,
+      right: this.props.size + this.state.spaceBetween + 10,
       top: offsetTop
     }
 


### PR DESCRIPTION
I tried to fix the shadow in the buttons, I put some margins and paddings in different places. I didn't test in center position and with different values in props.

![photo146354601660098633](https://cloud.githubusercontent.com/assets/10564179/19411416/b23ed2d0-92d7-11e6-8a5c-33a332157ede.jpg)
