### PR TITLE
Fix warning about shadow calculation in issue #114

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -130,8 +130,8 @@ export default class ActionButton extends Component {
     const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle ]
 
     return (
-      <Animated.View style={ styles.btnShadow }>
-        <View style={ actionButtonStyles }>
+      <View style={ styles.btnShadow }>
+        <Animated.View style={ actionButtonStyles }>
           <TouchableOpacity
             activeOpacity={0.85}
             onLongPress={this.props.onLongPress}
@@ -141,8 +141,8 @@ export default class ActionButton extends Component {
             }}>
             {this._renderButtonIcon()}
           </TouchableOpacity>
-        </View>
-      </Animated.View>
+        </AnimView>
+      </View>
     );
   }
 

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -104,6 +104,10 @@ export default class ActionButton extends Component {
     const animatedViewStyle = [
       styles.btn,
       {
+        backgroundColor: this.anim.interpolate({
+          inputRange: [0, 1],
+          outputRange: [this.props.buttonColor, buttonColorMax]
+        }),
         transform: [{
             scale: this.anim.interpolate({
               inputRange: [0, 1],
@@ -123,13 +127,10 @@ export default class ActionButton extends Component {
       height: this.props.size,
       borderRadius: this.props.size / 2,
       marginBottom: shadowHeight,
-      backgroundColor: this.anim.interpolate({
-        inputRange: [0, 1],
-        outputRange: [this.props.buttonColor, buttonColorMax]
-      })
+      backgroundColor: this.props.buttonColor
     }
 
-    const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle, combinedStyle ]
+    const actionButtonStyles = [ this.getActionButtonStyles(), combinedStyle, animatedViewStyle ]
 
     return (
       <View style={ !this.props.hideShadow && [ styles.btnShadow, combinedStyle, { marginHorizontal: 8 }]}>

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -130,7 +130,7 @@ export default class ActionButton extends Component {
     const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle ]
 
     return (
-      <View style={ styles.btnShadow }>
+      <Animated.View style={ styles.btnShadow }>
         <View style={ actionButtonStyles }>
           <TouchableOpacity
             activeOpacity={0.85}
@@ -142,7 +142,7 @@ export default class ActionButton extends Component {
             {this._renderButtonIcon()}
           </TouchableOpacity>
         </View>
-      </View>
+      </Animated.View>
     );
   }
 

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -104,15 +104,6 @@ export default class ActionButton extends Component {
     const animatedViewStyle = [
       styles.btn,
       {
-        width: this.props.size,
-        height: this.props.size,
-        borderRadius: this.props.size / 2,
-        marginHorizontal: 8,
-        marginBottom: shadowHeight,
-        backgroundColor: this.anim.interpolate({
-          inputRange: [0, 1],
-          outputRange: [this.props.buttonColor, buttonColorMax]
-        }),
         transform: [{
             scale: this.anim.interpolate({
               inputRange: [0, 1],
@@ -127,10 +118,21 @@ export default class ActionButton extends Component {
       },
     ];
 
-    const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle ]
+    const combinedStyle = {
+      width: this.props.size,
+      height: this.props.size,
+      borderRadius: this.props.size / 2,
+      marginBottom: shadowHeight,
+      backgroundColor: this.anim.interpolate({
+        inputRange: [0, 1],
+        outputRange: [this.props.buttonColor, buttonColorMax]
+      })
+    }
+
+    const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle, combinedStyle ]
 
     return (
-      <View style={ styles.btnShadow }>
+      <View style={ !this.props.hideShadow && [ styles.btnShadow, combinedStyle, { marginHorizontal: 8 }]}>
         <Animated.View style={ actionButtonStyles }>
           <TouchableOpacity
             activeOpacity={0.85}

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -38,7 +38,6 @@ export default class ActionButton extends Component {
 
   getActionButtonStyles() {
     const actionButtonStyles = [styles.actionBarItem, this.getButtonSize()];
-    if(!this.props.hideShadow) actionButtonStyles.push(styles.btnShadow);
     return actionButtonStyles;
   }
 
@@ -128,22 +127,21 @@ export default class ActionButton extends Component {
       },
     ];
 
-    if(!this.props.hideShadow && Platform.OS === 'android') animatedViewStyle.push(styles.btnShadow);
+    const actionButtonStyles = [ this.getActionButtonStyles(), animatedViewStyle ]
 
     return (
-      <View style={this.getActionButtonStyles()}>
-        <TouchableOpacity
-          activeOpacity={0.85}
-          onLongPress={this.props.onLongPress}
-          onPress={() => {
-            this.props.onPress()
-            if (this.props.children) this.animateButton()
-          }}>
-          <Animated.View
-            style={animatedViewStyle}>
+      <View style={ styles.btnShadow }>
+        <View style={ actionButtonStyles }>
+          <TouchableOpacity
+            activeOpacity={0.85}
+            onLongPress={this.props.onLongPress}
+            onPress={() => {
+              this.props.onPress()
+              if (this.props.children) this.animateButton()
+            }}>
             {this._renderButtonIcon()}
-          </Animated.View>
-        </TouchableOpacity>
+          </TouchableOpacity>
+        </View>
       </View>
     );
   }

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -141,7 +141,7 @@ export default class ActionButton extends Component {
             }}>
             {this._renderButtonIcon()}
           </TouchableOpacity>
-        </AnimView>
+        </Animated.View>
       </View>
     );
   }


### PR DESCRIPTION
This PR fixes #114 by removing the animated wrapper around the button icon and moving all those styles and animations to the button's outer View. An additional wrapping view was added to attach the shadow to. ~~Apparently an immediate child can provide the background in shadow calculations, so we do not need to attach a background to the shadow View.~~ This wrapper also gets the buttonColor set as background to avoid the warning.

As a side-effect, setting the `outRangeScale` makes the whole button scale rather than only the icon, which I consider a fix.

Note that as of writing, I have only tested this PR on iOS (React-native 0.38) so I cannot say if #109 is affected in any way.