### PR TITLE
RN ~0.39.0 fix for ActionButton children not rendering

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -73,7 +73,6 @@ export default class ActionButtonItem extends Component {
         ]}
       >
         <TouchableOpacity
-          style={{ flex:1 }}
           activeOpacity={this.props.activeOpacity || 0.85}
           onPress={this.props.onPress}
         >


### PR DESCRIPTION
fix for the issue https://github.com/mastermoo/react-native-action-button/issues/125
I do not know the full issue but we need to remove flex:1 to render ActionButton children
https://github.com/facebook/react-native/wiki/Breaking-Changes#039