### PR TITLE
Fixing wrong offsetX for RN 0.41.2

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -54,7 +54,7 @@ export default class ActionButton extends Component {
 
   getOffsetXY() {
     return {
-      paddingHorizontal: this.props.offsetX - 8,
+      paddingHorizontal: this.props.offsetX - 16,
       paddingBottom: this.props.verticalOrientation === 'up' ? this.props.offsetY : 0,
       paddingTop: this.props.verticalOrientation === 'down' ? this.props.offsetY : 0
     };


### PR DESCRIPTION
Now it shows the icons correctly aligned

Edit: Testing it a bit further, it works as it was before if you don't use `flex: 1`, if you use` flex: 1` in your parent view, you need it like in the PR, with -16 instead of - 8 in

`paddingHorizontal: this.props.offsetX - 8,`