### PR TITLE
Custom text and styles for button text

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -127,17 +127,19 @@ export default class ActionButton extends Component {
   }
 
   _renderButtonIcon() {
-    const { icon, btnOutRangeTxt, buttonTextColor } = this.props;
+    const { icon, btnOutRangeTxt, buttonTextStyle, buttonText } = this.props;
     if (icon) return icon;
 
+    const textColor = buttonTextStyle.color || 'rgba(255,255,255,1)'
+
     return (
-      <Animated.Text style={[styles.btnText, {
+      <Animated.Text style={[styles.btnText, buttonTextStyle, {
         color: this.anim.interpolate({
           inputRange: [0, 1],
-          outputRange: [buttonTextColor, (btnOutRangeTxt || buttonTextColor)]
+          outputRange: [textColor, (btnOutRangeTxt || textColor)]
         })
       }]}>
-        +
+        {buttonText}
       </Animated.Text>
     )
   }
@@ -230,7 +232,8 @@ ActionButton.propTypes = {
 
   bgColor: PropTypes.string,
   buttonColor: PropTypes.string,
-  buttonTextColor: PropTypes.string,
+  buttonTextStyle: Text.propTypes.style,
+  buttonText: PropTypes.string,
 
   offsetX: PropTypes.number,
   offsetY: PropTypes.number,
@@ -253,7 +256,8 @@ ActionButton.defaultProps = {
   active: false,
   bgColor: 'transparent',
   buttonColor: 'rgba(0,0,0,1)',
-  buttonTextColor: 'rgba(255,255,255,1)',
+  buttonTextStyle: {},
+  buttonText: '+',
   spacing: 20,
   outRangeScale: 1,
   autoInactive: true,

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | icon          | Component     | +                   | Custom component for ActionButton Icon
 | backdrop      | Component     | false               | Custom component for use as Backdrop (i.e. [BlurView](https://github.com/react-native-fellowship/react-native-blur#blur-view), [VibrancyView](https://github.com/react-native-fellowship/react-native-blur#vibrancy-view))
 | degrees       | number        | 135                 | degrees to rotate icon
-| buttonText    | string        | null                | use this to set a different text on the button
+| buttonText    | string        | +                   | use this to set a different text on the button
 | buttonTextStyle | style         | null                | use this to set the textstyle of the button's text
 | onReset       | function      | null                | use this to set the callback that will be called after the button reset's it's items
 | verticalOrientation | string  | "up"                | direction action buttons should expand.  One of: `up` or `down`

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | icon          | Component     | +                   | Custom component for ActionButton Icon
 | backdrop      | Component     | false               | Custom component for use as Backdrop (i.e. [BlurView](https://github.com/react-native-fellowship/react-native-blur#blur-view), [VibrancyView](https://github.com/react-native-fellowship/react-native-blur#vibrancy-view))
 | degrees       | number        | 135                 | degrees to rotate icon
-| text          | string        | null                | use this to set a different text on the button
-| buttonStyle   | style         | null                | use this to set the textstyle of the button's text
+| buttonText    | string        | null                | use this to set a different text on the button
+| buttonTextStyle | style         | null                | use this to set the textstyle of the button's text
 | onReset       | function      | null                | use this to set the callback that will be called after the button reset's it's items
 | verticalOrientation | string  | "up"                | direction action buttons should expand.  One of: `up` or `down`
 | backgroundTappable | boolean  | false               | make background tappable in active state of ActionButton


### PR DESCRIPTION
I was following the README and trying to add custom text to my button, but realized '+' was hardcoded. This change allows the user to add their own `buttonText` property. 

In addition, I've replaced the `buttonTextColor` property with `buttonTextStyle` to allow more customization and flexibility.