### PR TITLE
Add a prop to control the base elevation of the action button

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -39,6 +39,7 @@ export default class ActionButton extends Component {
     return [
       styles.overlay,
       {
+        elevation: this.props.elevation,
         justifyContent: this.props.verticalOrientation === 'up' ? 'flex-end' : 'flex-start'
       }
     ]
@@ -227,6 +228,7 @@ ActionButton.propTypes = {
   active: PropTypes.bool,
 
   position: PropTypes.string,
+  elevation: PropTypes.number,
 
   hideShadow: PropTypes.bool,
 


### PR DESCRIPTION
When a component is on the page that has an elevation of non-zero, the action button overlay does not go above those components (as elevated components in android are on a different z-level).

This adds a property to control the base elevation of the action button (which one would need to set to at least the elevation of the highest elevated component on the page).