### PR TITLE
Add a prop to control the base zIndex of the action button.

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -63,6 +63,7 @@ export default class ActionButton extends Component {
       styles.overlay,
       {
         elevation: this.props.elevation,
+        zIndex: this.props.zIndex,
         justifyContent: this.props.verticalOrientation === 'up' ? 'flex-end' : 'flex-start'
       }
     ]
@@ -256,6 +257,7 @@ ActionButton.propTypes = {
 
   position: PropTypes.string,
   elevation: PropTypes.number,
+  zIndex: PropTypes.number,
 
   hideShadow: PropTypes.bool,
 


### PR DESCRIPTION
Hit the same issue as described on #158 when I adjusted the elevated components to work on iOS (adding shadow* and zIndex).

This allows us to set a base zIndex of the Action Button.

---

On another note; this component should probably just default elevation and zIndex to high-ish values.