### PR TITLE
Apply passed zIndex to the buttons to put them above the overlay

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -135,7 +135,7 @@ export default class ActionButton extends Component {
     const Touchable = getTouchableComponent(this.props.useNativeFeedback);
 
     return (
-      <View style={{ paddingHorizontal: this.props.offsetX }}>
+      <View style={{ paddingHorizontal: this.props.offsetX, zIndex: this.props.zIndex }}>
         <Touchable
           background={touchableBackground}
           activeOpacity={this.props.activeOpacity}
@@ -184,7 +184,8 @@ export default class ActionButton extends Component {
       alignSelf: 'stretch',
       // backgroundColor: 'purple',
       justifyContent: verticalOrientation === 'up' ? 'flex-end' : 'flex-start',
-      paddingTop: this.props.verticalOrientation === 'down' ? this.props.spacing : 0
+      paddingTop: this.props.verticalOrientation === 'down' ? this.props.spacing : 0,
+      zIndex: this.props.zIndex,
     };
 
     return (


### PR DESCRIPTION
@mastermoo Apologies. I was apparently too eager in pushing that last fix ( #169 ) upstream. Using it breaks actually interacting with the buttons as the buttons are rendered in a sibling. This commit fixes that and I've confirmed the same issue doesn't exist with `elevation`.