### PR TITLE
WIP : Fix square ripple effect on Android

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -136,20 +136,22 @@ export default class ActionButton extends Component {
 
     return (
       <View style={{ paddingHorizontal: this.props.offsetX, zIndex: this.props.zIndex }}>
-        <Touchable
-          background={touchableBackground}
-          activeOpacity={this.props.activeOpacity}
-          onLongPress={this.props.onLongPress}
-          onPress={() => {
-            this.props.onPress()
-            if (this.props.children) this.animateButton()
-          }}>
-          <Animated.View style={[wrapperStyle, !this.props.hideShadow && shadowStyle]}>
-            <Animated.View style={[buttonStyle, animatedViewStyle]}>
-              {this._renderButtonIcon()}
+        <Animated.View style={[wrapperStyle, !this.props.hideShadow && shadowStyle]}>
+          <Touchable
+            background={touchableBackground}
+            activeOpacity={this.props.activeOpacity}
+            onLongPress={this.props.onLongPress}
+            onPress={() => {
+              this.props.onPress()
+              if (this.props.children) this.animateButton()
+            }}>
+            <Animated.View style={[wrapperStyle, !this.props.hideShadow && shadowStyle]}>
+              <Animated.View style={[buttonStyle, animatedViewStyle]}>
+                {this._renderButtonIcon()}
+              </Animated.View>
             </Animated.View>
-          </Animated.View>
-        </Touchable>
+          </Touchable>
+        </Animated.View>
       </View>
     );
   }
@@ -174,7 +176,7 @@ export default class ActionButton extends Component {
 
   _renderActions() {
     const { children, verticalOrientation } = this.props;
-    
+
     if (!this.state.active) return null;
 
     const actionButtons = !Array.isArray(children) ? [children] : children;
@@ -184,7 +186,7 @@ export default class ActionButton extends Component {
       alignSelf: 'stretch',
       // backgroundColor: 'purple',
       justifyContent: verticalOrientation === 'up' ? 'flex-end' : 'flex-start',
-      paddingTop: this.props.verticalOrientation === 'down' ? this.props.spacing : 0,
+      paddingTop: verticalOrientation === 'down' ? this.props.spacing : 0,
       zIndex: this.props.zIndex,
     };
 

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -145,10 +145,8 @@ export default class ActionButton extends Component {
               this.props.onPress()
               if (this.props.children) this.animateButton()
             }}>
-            <Animated.View style={[wrapperStyle, !this.props.hideShadow && shadowStyle]}>
-              <Animated.View style={[buttonStyle, animatedViewStyle]}>
-                {this._renderButtonIcon()}
-              </Animated.View>
+            <Animated.View style={[buttonStyle, animatedViewStyle]}>
+              {this._renderButtonIcon()}
             </Animated.View>
           </Touchable>
         </Animated.View>

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { StyleSheet, Text, View, Animated, 
+import { StyleSheet, Text, View, Animated,
   TouchableNativeFeedback, TouchableWithoutFeedback, Dimensions, Platform } from 'react-native';
 import { shadowStyle, alignItemsMap, getTouchableComponent, isAndroid, touchableBackground, DEFAULT_ACTIVE_OPACITY } from './shared';
 
@@ -65,16 +65,16 @@ export default class ActionButtonItem extends Component {
 
     return (
       <Animated.View pointerEvents="box-none" style={animatedViewStyle}>
-        <Touchable
-          background={touchableBackground}
-          activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
-          onPress={this.props.onPress}>
-          <View
-            style={[buttonStyle, !hideShadow && shadowStyle, this.props.style]}
-          >
-            {this.props.children}
-          </View>
-        </Touchable>
+        <View style={[buttonStyle, !hideShadow && shadowStyle, this.props.style]}>
+          <Touchable
+            background={touchableBackground}
+            activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
+            onPress={this.props.onPress}>
+            <View style={buttonStyle}>
+              {this.props.children}
+            </View>
+          </Touchable>
+        </View>
         {this._renderTitle()}
       </Animated.View>
     );
@@ -96,14 +96,14 @@ export default class ActionButtonItem extends Component {
     const textStyles = [styles.textContainer, positionStyles, textContainerStyle, !hideShadow && shadowStyle];
 
     return (
-      <TextTouchable
-        background={touchableBackground}
-        activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
-        onPress={this.props.onPress}>
-        <View style={textStyles}>
-          <Text style={[styles.text, this.props.textStyle]}>{this.props.title}</Text>
-        </View>
-      </TextTouchable>
+      <View style={textStyles}>
+        <TextTouchable
+          background={touchableBackground}
+          activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
+          onPress={this.props.onPress}>
+            <Text style={[styles.text, this.props.textStyle]}>{this.props.title}</Text>
+        </TextTouchable>
+      </View>
     );
   }
 }

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -103,7 +103,7 @@ export default class ActionButtonItem extends Component {
           onPress={this.props.onPress}>
             <View style={styles.viewTextWrapper}>
               <Text style={[styles.text, this.props.textStyle]}>{this.props.title}</Text>
-            <View>
+            </View>
         </TextTouchable>
       </View>
     );

--- a/shared.js
+++ b/shared.js
@@ -29,6 +29,6 @@ export function getTouchableComponent(useNativeFeedback) {
 
 export const touchableBackground = isAndroid
   ? Platform['Version'] >= 21
-    ? TouchableNativeFeedback.Ripple('rgba(255,255,255,0.75)', false)
+    ? TouchableNativeFeedback.Ripple('rgba(255,255,255,0.75)', true)
     : TouchableNativeFeedback.SelectableBackground()
   : undefined;


### PR DESCRIPTION
Hello,

Given this issue: https://github.com/facebook/react-native/issues/6480

TouchableNativeFeedback should be wrapped inside the circle so it can stop at its parent boundaries instead of doing a square effect.

Note that I didn't try this on iOS but I will in a few days and I'm not sure it's the best way to fix the square ripple effect.