### PR TITLE
Add support to hide button and/or label shadow

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import { StyleSheet, Text, View, Animated, 
+import { StyleSheet, Text, View, Animated,
   TouchableNativeFeedback, TouchableWithoutFeedback, Dimensions, Platform } from 'react-native';
 import { shadowStyle, alignItemsMap, getTouchableComponent, isAndroid, touchableBackground, DEFAULT_ACTIVE_OPACITY } from './shared';
 
@@ -83,9 +83,10 @@ export default class ActionButtonItem extends Component {
   _renderTitle() {
     if (!this.props.title) return null;
 
-    const { textContainerStyle, hideShadow, offsetX, parentSize, size, position, spaceBetween } = this.props;
+    const { textContainerStyle, hideLabelShadow, offsetX, parentSize, size, position, spaceBetween } = this.props;
     const offsetTop = Math.max((size / 2) - (TEXT_HEIGHT/2), 0);
     const positionStyles = { top: offsetTop };
+    const hideShadow = hideLabelShadow === undefined ? this.props.hideShadow : hideLabelShadow;
 
     if (position !== 'center') {
       positionStyles[position] = offsetX + (parentSize-size)/2 + size + spaceBetween;

--- a/README.md
+++ b/README.md
@@ -127,3 +127,4 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | spaceBetween  | number        | 15                  | use this to set the space between the Button and the text container
 | useNativeFeedback | boolean   | true                | whether to use TouchableNativeFeedback on Android
 | activeOpacity | number        | 0.85                | activeOpacity props of TouchableOpacity
+| hideLabelShadow | boolean     | same as hideShadow  | use this to hide the button's label default elevation and boxShadow


### PR DESCRIPTION
Hi,

I've found useful to be able to control both the action button and the items' label shadow separately. This can be achieved by replacing the `hideShadow` prop by a `hideActionButtonShadow` and a `hideLabelShadow` props.

Hope you also find this useful so this can be merged :)