### PR TITLE
Adds a grid proptype to display action items as a grid.

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -177,8 +177,8 @@ export default class ActionButton extends Component {
   }
 
   _renderActions() {
-    const { children, verticalOrientation } = this.props;
-    
+    const { children, verticalOrientation, grid } = this.props;
+
     if (!this.state.active) return null;
 
     const actionButtons = !Array.isArray(children) ? [children] : children;
@@ -194,22 +194,24 @@ export default class ActionButton extends Component {
 
     return (
       <View style={actionStyle} pointerEvents={'box-none'}>
-        {actionButtons.map((ActionButton, idx) => (
-          <ActionButtonItem
-            key={idx}
-            anim={this.anim}
-            {...this.props}
-            {...ActionButton.props}
-            parentSize={this.props.size}
-            btnColor={this.props.btnOutRange}
-            onPress={() => {
-              if (this.props.autoInactive){
-                this.timeout = setTimeout(this.reset.bind(this), 200);
-              }
-              ActionButton.props.onPress();
-            }}
-          />
-        ))}
+        <View style={grid && styles.grid}>
+          {actionButtons.map((ActionButton, idx) => (
+            <ActionButtonItem
+              key={idx}
+              anim={this.anim}
+              {...this.props}
+              {...ActionButton.props}
+              parentSize={this.props.size}
+              btnColor={this.props.btnOutRange}
+              onPress={() => {
+                if (this.props.autoInactive){
+                  this.timeout = setTimeout(this.reset.bind(this), 200);
+                }
+                ActionButton.props.onPress();
+              }}
+            />
+          ))}
+        </View>
       </View>
     );
   }
@@ -260,6 +262,7 @@ ActionButton.propTypes = {
   resetToken: PropTypes.any,
   active: PropTypes.bool,
 
+  grid: PropTypes.bool,
   position: PropTypes.string,
   elevation: PropTypes.number,
   zIndex: PropTypes.number,
@@ -312,6 +315,7 @@ ActionButton.defaultProps = {
   backdrop: false,
   degrees: 45,
   position: 'right',
+  grid: false,
   offsetX: 30,
   offsetY: 30,
   size: 56,
@@ -337,4 +341,9 @@ const styles = StyleSheet.create({
     fontSize: 24,
     backgroundColor: 'transparent',
   },
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+  }
 });

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -177,7 +177,7 @@ export default class ActionButton extends Component {
   }
 
   _renderActions() {
-    const { children, verticalOrientation, grid } = this.props;
+    const { children, verticalOrientation, grid, inverted } = this.props;
 
     if (!this.state.active) return null;
 
@@ -194,11 +194,12 @@ export default class ActionButton extends Component {
 
     return (
       <View style={actionStyle} pointerEvents={'box-none'}>
-        <View style={grid && styles.grid}>
+        <View style={[grid && styles.grid, inverted && styles.inverted]}>
           {actionButtons.map((ActionButton, idx) => (
             <ActionButtonItem
               key={idx}
               anim={this.anim}
+              inverted={inverted}
               {...this.props}
               {...ActionButton.props}
               parentSize={this.props.size}
@@ -211,8 +212,8 @@ export default class ActionButton extends Component {
               }}
             />
           ))}
-        </View>
       </View>
+    </View>
     );
   }
 
@@ -263,6 +264,7 @@ ActionButton.propTypes = {
   active: PropTypes.bool,
 
   grid: PropTypes.bool,
+  inverted: PropTypes.bool,
   position: PropTypes.string,
   elevation: PropTypes.number,
   zIndex: PropTypes.number,
@@ -316,6 +318,7 @@ ActionButton.defaultProps = {
   degrees: 45,
   position: 'right',
   grid: false,
+  inverted: false,
   offsetX: 30,
   offsetY: 30,
   size: 56,
@@ -345,5 +348,8 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     flexWrap: 'wrap',
     justifyContent: 'center',
+  },
+  inverted: {
+    transform: [{ scaleY: -1 }]
   }
 });

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -24,6 +24,7 @@ export default class ActionButtonItem extends Component {
   static get propTypes() {
     return {
       active: PropTypes.bool,
+      inverted: PropTypes.bool,
       useNativeFeedback: PropTypes.bool,
       fixNativeFeedbackRadius: PropTypes.bool,
       nativeFeedbackRippleColor: PropTypes.string,
@@ -32,10 +33,9 @@ export default class ActionButtonItem extends Component {
   }
 
   render() {
-    const { size, position, verticalOrientation, hideShadow, spacing } = this.props;
+    const { size, position, verticalOrientation, hideShadow, spacing, inverted } = this.props;
 
     if (!this.props.active) return null;
-
     const animatedViewStyle = {
       marginBottom: -SHADOW_SPACE,
       alignItems: alignItemsMap[position],
@@ -48,6 +48,9 @@ export default class ActionButtonItem extends Component {
             inputRange: [0, 1],
             outputRange: [verticalOrientation === 'down' ? -40 : 40, 0]
           }),
+        },
+        {
+          scaleY: inverted === true ? -1 : 1
         }
       ],
     };

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/mastermoo/react-native-action-button.git"
+    "url": "https://github.com/nonotest/react-native-action-button.git"
   },
   "keywords": [
     "react-native",
@@ -22,7 +22,7 @@
   "author": "Yousef Kamawall",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/mastermoo/react-native-action-button/issues"
+    "url": "https://github.com/nonotest/react-native-action-button/issues"
   },
-  "homepage": "https://github.com/mastermoo/react-native-action-button"
+  "homepage": "https://github.com/nonotest/react-native-action-button"
 }


### PR DESCRIPTION
Would you be interested in a grid prop to display items in a grid instead of just one vertical column?
eg:

![image](https://user-images.githubusercontent.com/2551341/27255096-4492b734-53c9-11e7-820d-3a31111bb607.png)

I need something like this for my project and believe it's pretty cool.
Let me know!
