### PR TITLE
Remove unnecessary import

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -6,7 +6,6 @@ import {
   View,
   Animated,
   TouchableOpacity,
-  Platform
 } from "react-native";
 import ActionButtonItem from "./ActionButtonItem";
 import {
@@ -178,7 +177,7 @@ export default class ActionButton extends Component {
     };
 
     const Touchable = getTouchableComponent(this.props.useNativeFeedback);
-    const parentStyle = Platform.OS === "android" &&
+    const parentStyle = isAndroid &&
       this.props.fixNativeFeedbackRadius
       ? {
           right: this.props.offsetX,

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -8,7 +8,6 @@ import {
   TouchableNativeFeedback,
   TouchableWithoutFeedback,
   Dimensions,
-  Platform
 } from "react-native";
 import {
   shadowStyle,
@@ -90,7 +89,7 @@ export default class ActionButtonItem extends Component {
 
     const Touchable = getTouchableComponent(this.props.useNativeFeedback);
 
-    const parentStyle = Platform.OS === "android" &&
+    const parentStyle = isAndroid &&
       this.props.fixNativeFeedbackRadius
       ? {
           height: size,


### PR DESCRIPTION
Hi! Do we still need `Platform` here? It seems unnecessary to me since we already have `isAndroid` from './shared' for that.