### PR TITLE
Make non-string value/component as title

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -168,6 +168,19 @@ export default class ActionButtonItem extends Component {
       textContainerStyle
     ];
 
+    const title = (
+      React.isValidElement(this.props.title) ?
+        this.props.title
+      : (
+        <Text
+          allowFontScaling={false}
+          style={[styles.text, this.props.textStyle]}
+        >
+          {this.props.title}
+        </Text>
+      )
+    )
+
     return (
       <TextTouchable
         background={touchableBackground(
@@ -178,12 +191,7 @@ export default class ActionButtonItem extends Component {
         onPress={this.props.onPress}
       >
         <View style={textStyles}>
-          <Text
-            allowFontScaling={false}
-            style={[styles.text, this.props.textStyle]}
-          >
-            {this.props.title}
-          </Text>
+          {title}
         </View>
       </TextTouchable>
     );


### PR DESCRIPTION
I think this PR closes #172 by moving the value of title outside of Text if the value is a valid react element.

This is how I would then make the custom title:
```
class Basic extends Component {
  render() {
    const light_bulb = (
      <View style={{flex: 1, flexDirection: "row", alignItems: "center"}}>
        <Image
          style={{width: 30, height: 30, marginRight: 5}}
          source={{uri: "https://image.flaticon.com/icons/png/128/167/167745.png"}} />
        <Text style={{fontSize: 12, color: "#444"}}>Light Bulb</Text>
      </View>
    )
    return (
      <View style={styles.container}>
        <Text style={styles.welcome}>
          Basic Example
        </Text>
        <ActionButton buttonColor="rgba(231,76,60,1)">
          <ActionButton.Item buttonColor='#9b59b6' title="New Task" onPress={() => console.log("notes tapped!")}>
            <Icon name="ios-add" style={styles.actionButtonIcon} />
          </ActionButton.Item>
          <ActionButton.Item buttonColor='#3498db' title="Notifications" onPress={() => {}}>
            <Icon name="ios-notifications" style={styles.actionButtonIcon} />
          </ActionButton.Item>
          <ActionButton.Item buttonColor='#1abc9c' title={light_bulb} textContainerStyle={{height: 40, top: 6}} onPress={() => {}}>
            <Icon name="md-done-all" style={styles.actionButtonIcon} />
          </ActionButton.Item>
        </ActionButton>
      </View>
    );
  }
}
```

![screenshot_1501209309](https://user-images.githubusercontent.com/8341867/28700318-33c1141c-7379-11e7-9091-96467978f747.png)
