### PR TITLE
Switch MainButton to use Margin not Padding, and fix shadow prop warning

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -186,7 +186,7 @@ export default class ActionButton extends Component {
           borderRadius: this.props.size / 2,
           width: this.props.size
         }
-      : { paddingHorizontal: this.props.offsetX, zIndex: this.props.zIndex };
+      : { marginHorizontal: this.props.offsetX, zIndex: this.props.zIndex };
 
     return (
       <View style={parentStyle}>

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -108,15 +108,11 @@ export default class ActionButtonItem extends Component {
         style={[animatedViewStyle, parentStyle]}
       >
         <View
-          style={[
-            {
-              width: this.props.size,
-              height: this.props.size,
-              borderRadius: size / 2
-            },
-            !hideShadow && shadowStyle,
-            !hideShadow && this.props.shadowStyle
-          ]}
+          style={{
+            width: this.props.size,
+            height: this.props.size,
+            borderRadius: size / 2
+          }}
         >
           <Touchable
             background={touchableBackground(
@@ -126,7 +122,10 @@ export default class ActionButtonItem extends Component {
             activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
             onPress={this.props.onPress}
           >
-            <View style={[buttonStyle]}>
+            <View style={[
+              buttonStyle,
+              !hideShadow ? {...shadowStyle, ...this.props.shadowStyle} : null
+            ]}>
               {this.props.children}
             </View>
           </Touchable>


### PR DESCRIPTION
The `_renderMainButton()` root element styles currently has `paddingHorizontal` on iOS to position it correctly, which works fine but causes the element to receive presses either side of the button as well as inside the button. Switching to `marginHorizontal` means that presses just outside the element will not get caught.