### PR TITLE
Fix shadow style on Android

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -189,7 +189,12 @@ export default class ActionButton extends Component {
       : { paddingHorizontal: this.props.offsetX, zIndex: this.props.zIndex };
 
     return (
-      <View style={parentStyle}>
+      <View style={[
+        parentStyle,
+        !this.props.hideShadow && shadowStyle,
+        !this.props.hideShadow && this.props.shadowStyle
+      ]}
+      >
         <Touchable
           background={touchableBackground(
             this.props.nativeFeedbackRippleColor,
@@ -203,11 +208,7 @@ export default class ActionButton extends Component {
           }}
         >
           <Animated.View
-            style={[
-              wrapperStyle,
-              !this.props.hideShadow && shadowStyle,
-              !this.props.hideShadow && this.props.shadowStyle
-            ]}
+            style={wrapperStyle}
           >
             <Animated.View style={[buttonStyle, animatedViewStyle]}>
               {this._renderButtonIcon()}


### PR DESCRIPTION
Resolve issue #206 where the shadow was being cropped and not aligned such as the following image.

![screenshot_2017-08-21-14-13-23-1](https://user-images.githubusercontent.com/11003755/29539358-6064a6f6-867e-11e7-866a-e21670162e04.png)
 

This is occurring because the styles pertaining to the shadow are being applied to the animated view instead of the view. Changing the fix gives the output users want to see:

![pasted image at 2017_08_21 02_45 pm](https://user-images.githubusercontent.com/11003755/29539584-76f681b8-867f-11e7-9aa8-605b41223bb0.png)
