### PR TITLE
Add render prop to ActionButton

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -222,7 +222,8 @@ export default class ActionButton extends Component {
   }
 
   _renderButtonIcon() {
-    const { icon, btnOutRangeTxt, buttonTextStyle, buttonText } = this.props;
+    const { icon, renderIcon, btnOutRangeTxt, buttonTextStyle, buttonText } = this.props;
+    if (renderIcon) return renderIcon(this.state.active);
     if (icon) return icon;
 
     const textColor = buttonTextStyle.color || "rgba(255,255,255,1)";
@@ -344,6 +345,8 @@ ActionButton.propTypes = {
     PropTypes.number
   ]),
 
+  renderIcon: PropTypes.func,
+  
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,
   buttonColor: PropTypes.string,

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -224,7 +224,10 @@ export default class ActionButton extends Component {
   _renderButtonIcon() {
     const { icon, renderIcon, btnOutRangeTxt, buttonTextStyle, buttonText } = this.props;
     if (renderIcon) return renderIcon(this.state.active);
-    if (icon) return icon;
+    if (icon) {
+      console.warn('react-native-action-button: The `icon` prop is deprecated! Use `renderIcon` instead.');
+      return icon;
+    }
 
     const textColor = buttonTextStyle.color || "rgba(255,255,255,1)";
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | onPressIn     | function      | null                | fires, before ActionButton is released
 | onPressOut    | function      | null                | fires, after ActionButton is released
 | onLongPress   | function      | null                | fires, when ActionButton is long pressed
-| icon          | Component     | +                   | Custom component for ActionButton Icon
+| renderIcon    | function      | null                | Function to render the component for ActionButton Icon. It is passed a boolean, `active`, which is true if the FAB has been expanded, and false if it is collapsed, allowing you to show a different icon when the ActionButton Items are expanded.
+| icon          | Component     | +                   | **Deprecated, use `renderIcon`** Custom component for ActionButton Icon
 | backdrop      | Component     | false               | Custom component for use as Backdrop (i.e. [BlurView](https://github.com/react-native-fellowship/react-native-blur#blur-view), [VibrancyView](https://github.com/react-native-fellowship/react-native-blur#vibrancy-view))
 | degrees       | number        | 135                 | degrees to rotate icon
 | buttonText    | string        | +                   | use this to set a different text on the button


### PR DESCRIPTION
This PR allows the ActionButton component to take a render prop, `renderIcon` as an alternative to the `icon` prop.
Currently if you want to use a separate icon in the action button when the buttons are expanded, you have to handle some kind of `expanded: true/false` state on your parent component, which seemed unnecessary to me as that state is already handled on the ActionButton component.

This PR allows this instead:
```JSX
<ActionButton
    renderIcon={(active) => (
        active ? (
            <Icon name="expanded-icon" />
        ) : (
            <Icon name="collapsed-icon" />
        )
    )}
/>
```

It's backwards compatible, so if no `renderIcon` prop is passed, it works the exact same as before; using `icon` if passed, otherwise the default.

I've made the `renderIcon` prop take precedence over `icon`, but that can be switched if needed.

If you're happy with the PR I can add details to the docs before merging, just let me know.