### PR TITLE
 Added width, height and borderRadius props for ActionButtonItem

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -54,7 +54,9 @@ export default class ActionButtonItem extends Component {
       position,
       verticalOrientation,
       hideShadow,
-      spacing
+      spacing,
+      width,
+      height
     } = this.props;
 
     if (!this.props.active) return null;
@@ -78,9 +80,9 @@ export default class ActionButtonItem extends Component {
     const buttonStyle = {
       justifyContent: "center",
       alignItems: "center",
-      width: size,
-      height: size,
-      borderRadius: size / 2,
+      width: width || size,
+      height: width || size,
+      borderRadius: borderRadius || size ? size / 2 : 0,
       backgroundColor: this.props.buttonColor || this.props.btnColor
     };
 

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -82,7 +82,7 @@ export default class ActionButtonItem extends Component {
       justifyContent: "center",
       alignItems: "center",
       width: width || size,
-      height: width || size,
+      height: height || size,
       borderRadius: borderRadius || size ? size / 2 : 0,
       backgroundColor: this.props.buttonColor || this.props.btnColor
     };

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -56,7 +56,8 @@ export default class ActionButtonItem extends Component {
       hideShadow,
       spacing,
       width,
-      height
+      height,
+      borderRadius
     } = this.props;
 
     if (!this.props.active) return null;

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | Property      | Type          | Default             | Description |
 | ------------- |:-------------:|:------------:       | ----------- |
 | size          | number        | parentSize          | use this to change the size of the Button
+| width         | number        | parentSize          | use this to change the height of the Button
+| height        | number        | parentSize          | use this to change the width of the Button
+| borderRadius  | number        | parentSize          | use this to change the border radius of the Button
 | title         | string        | undefined           | the title shown next to the button. When `undefined` the title is not hidden
 | onPress       | func          | null                | **required** function, triggers when a button is tapped
 | buttonColor   | string        | same as + button    | background color of the Button


### PR DESCRIPTION
if width is not provided size will be taken as default
if height is not provided size will be taken as default
if borderRadius is not provided size / 2 will be calculated
