### PR TITLE
Adds activeColor and renderActiveIcon props

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -372,6 +372,7 @@ ActionButton.propTypes = {
   ]),
 
   renderIcon: PropTypes.func,
+  renderActiveIcon: PropTypes.func,
   
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -160,7 +160,7 @@ export default class ActionButton extends Component {
         inputRange: [0, 1],
         outputRange: [
           this.props.buttonColor,
-          this.props.btnOutRange || this.props.buttonColor
+          this.props.activeColor || this.props.btnOutRange || this.props.buttonColor
         ]
       }),
       width: this.props.size,
@@ -222,8 +222,31 @@ export default class ActionButton extends Component {
   }
 
   _renderButtonIcon() {
-    const { icon, renderIcon, btnOutRangeTxt, buttonTextStyle, buttonText } = this.props;
-    if (renderIcon) return renderIcon(this.state.active);
+    const { icon, renderIcon, btnOutRangeTxt, buttonTextStyle, buttonText, renderActiveIcon } = this.props;
+    if (renderIcon) {
+      if (renderActiveIcon) {
+        const iconStyle = {
+          opacity: this.anim.interpolate({
+            inputRange: [0, 1],
+            outputRange: [1, 0]
+          })
+        };
+        const activeIconStyle = {
+          opacity: this.anim.interpolate({
+            inputRange: [0, 1],
+            outputRange: [0, 1]
+          }),
+          position: "absolute"
+        };
+        return (
+          <View>
+            <Animated.View style={iconStyle}>{renderIcon(this.state.active)}</Animated.View>
+            <Animated.View style={activeIconStyle}>{renderActiveIcon(this.state.active)}</Animated.View>
+          </View>
+        );
+      }
+      return renderIcon(this.state.active);
+    }
     if (icon) {
       console.warn('react-native-action-button: The `icon` prop is deprecated! Use `renderIcon` instead.');
       return icon;
@@ -353,6 +376,7 @@ ActionButton.propTypes = {
   bgColor: PropTypes.string,
   bgOpacity: PropTypes.number,
   buttonColor: PropTypes.string,
+  activeColor: PropTypes.string,
   buttonTextStyle: Text.propTypes.style,
   buttonText: PropTypes.string,
 

--- a/ActionButton.js
+++ b/ActionButton.js
@@ -241,7 +241,7 @@ export default class ActionButton extends Component {
         return (
           <View>
             <Animated.View style={iconStyle}>{renderIcon(this.state.active)}</Animated.View>
-            <Animated.View style={activeIconStyle}>{renderActiveIcon(this.state.active)}</Animated.View>
+            <Animated.View style={activeIconStyle}>{renderActiveIcon()}</Animated.View>
           </View>
         );
       }

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | position      | string        | "right" / "center"  | one of: `left` `center` and `right`
 | bgColor       | string        | "transparent"       | background color when ActionButtons are visible
 | buttonColor   | string        | "rgba(0,0,0,1)"     | background color of the +Button **(must be rgba value!)**
+| activeColor   | string        | "rgba(0,0,0,1)"     | background color of the +Button will crossfade to this color when active **(must be rgba value!)**
 | spacing       | number        | 20                  | spacing between the `ActionButton.Item`s
 | offsetX       | number        | 30                  | offset from the left/right side of the screen
 | offsetY       | number        | 30                  | offset from the bottom/top of the screen
@@ -116,6 +117,7 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | onPressOut    | function      | null                | fires, after ActionButton is released
 | onLongPress   | function      | null                | fires, when ActionButton is long pressed
 | renderIcon    | function      | null                | Function to render the component for ActionButton Icon. It is passed a boolean, `active`, which is true if the FAB has been expanded, and false if it is collapsed, allowing you to show a different icon when the ActionButton Items are expanded.
+| renderActiveIcon| function    | null                | Function to render the component for ActionButton Icon when the button is active. If defined, the icon will crossfade into the active icon
 | icon          | Component     | +                   | **Deprecated, use `renderIcon`** Custom component for ActionButton Icon
 | backdrop      | Component     | false               | Custom component for use as Backdrop (i.e. [BlurView](https://github.com/react-native-fellowship/react-native-blur#blur-view), [VibrancyView](https://github.com/react-native-fellowship/react-native-blur#vibrancy-view))
 | degrees       | number        | 135                 | degrees to rotate icon


### PR DESCRIPTION
If defined, action button background color and/or icon will crossfade to these when the button is activated. Looks nicer than simply using the "active" parameter of renderIcon to change it ;)

![ezgif-2-0971d087f0](https://user-images.githubusercontent.com/1567227/37803634-3f80e46a-2ded-11e8-99fb-7e13b70a77d1.gif)
