### PR TITLE
Add size property to ActionButonItemProperties interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,7 @@ export interface ActionButtonProperties extends ViewProperties {
 }
 
 export interface ActionButtonItemProperties extends ViewProperties {
+  size?: number,
   title?: string
   onPress?:	() => void
   buttonColor?:	string


### PR DESCRIPTION
ActionButtonItem has `size` property but it's not defined in the interface.