### PR TITLE
Fix native feedback radius

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -185,7 +185,7 @@ export default class ActionButton extends Component {
     const parentStyle = isAndroid &&
       this.props.fixNativeFeedbackRadius
       ? {
-          right: this.props.offsetX,
+          marginHorizontal: this.props.offsetX,
           zIndex: this.props.zIndex,
           borderRadius: this.props.size / 2,
           width: this.props.size

--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -85,28 +85,27 @@ export default class ActionButtonItem extends Component {
     };
 
     if (position !== "center")
-      buttonStyle[position] = (this.props.parentSize - size) / 2;
+      animatedViewStyle[position] = (this.props.parentSize - size) / 2;
 
     const Touchable = getTouchableComponent(this.props.useNativeFeedback);
 
-    const parentStyle = isAndroid &&
-      this.props.fixNativeFeedbackRadius
-      ? {
-          height: size,
-          marginBottom: spacing,
-          right: this.props.offsetX,
-          borderRadius: this.props.size / 2
+    const parentStyle = {
+          marginHorizontal: this.props.offsetX,
+          marginBottom: spacing + SHADOW_SPACE,
+          borderRadius: this.props.size / 2,
         }
-      : {
-          paddingHorizontal: this.props.offsetX,
-          height: size + SHADOW_SPACE + spacing
-        };
+
     return (
       <Animated.View
         pointerEvents="box-none"
-        style={[animatedViewStyle, parentStyle]}
+        style={[animatedViewStyle]}
       >
-        <View>
+         <View
+          style={[
+            parentStyle,
+            !hideShadow && isAndroid ? {...shadowStyle, ...this.props.shadowStyle} : null
+          ]}
+        > 
           <Touchable
             testID={this.props.testID}
             background={touchableBackground(
@@ -118,7 +117,7 @@ export default class ActionButtonItem extends Component {
           >
             <View style={[
               buttonStyle,
-              !hideShadow ? {...shadowStyle, ...this.props.shadowStyle} : null
+              !hideShadow && !isAndroid ? {...shadowStyle, ...this.props.shadowStyle} : null
             ]}>
               {this.props.children}
             </View>
@@ -177,8 +176,7 @@ export default class ActionButtonItem extends Component {
     return (
       <TextTouchable
         background={touchableBackground(
-          this.props.nativeFeedbackRippleColor,
-          this.props.fixNativeFeedbackRadius
+          this.props.nativeFeedbackRippleColor
         )}
         activeOpacity={this.props.activeOpacity || DEFAULT_ACTIVE_OPACITY}
         onPress={this.props.onPress}

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ export interface ActionButtonProperties extends ViewProperties {
   size?: number,
   autoInactive?: boolean,
   onPress?: () => void,
+  renderIcon?: (active: boolean) => React.ReactElement,
   backdrop?: boolean | object,
   degrees?: number,
   verticalOrientation?: 'up' | 'down',


### PR DESCRIPTION
When setting fixNativeFeedbackRadius to true and giving the ActionButton position 'Center'. The AtionButton and ActionButtonItems would have an offset from the center due to incorrect styling.

fixNativeFeedbackRadius also caused an ugly shadow on ActionButtonItems and their respective lable, and also a cropped dropshadow.

For the ActionButtonItem, this was due to the shadow styling was set on the wrong element for android. As for the lable, we do not need to set the fixNativeFeedbackRadius to the touchableBackground (the lable is rectangular anyway). You'll notice that the ripple effect on the lable would extend in a circular fashion outside the borders of the lable.