### PR TITLE
fix render icon return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export interface ActionButtonProperties extends ViewProperties {
   size?: number,
   autoInactive?: boolean,
   onPress?: () => void,
-  renderIcon?: (active: boolean) => React.ReactElement,
+  renderIcon?: (active: boolean) => React.ReactElement<any>,
   backdrop?: boolean | object,
   degrees?: number,
   verticalOrientation?: 'up' | 'down',


### PR DESCRIPTION
I have some problem with tslint on using react-native-action-button renderIcon function. This function should return generic type 'ReactElement<P>'. So I fixed this issue and created PR for you. Please, check it. 