### PR TITLE
Added numberOfLines prop for text truncation

### DIFF
--- a/ActionButtonItem.js
+++ b/ActionButtonItem.js
@@ -34,7 +34,8 @@ export default class ActionButtonItem extends Component {
       useNativeFeedback: true,
       activeOpacity: DEFAULT_ACTIVE_OPACITY,
       fixNativeFeedbackRadius: false,
-      nativeFeedbackRippleColor: "rgba(255,255,255,0.75)"
+      nativeFeedbackRippleColor: "rgba(255,255,255,0.75)",
+      numberOfLines: 1,
     };
   }
 
@@ -44,7 +45,8 @@ export default class ActionButtonItem extends Component {
       useNativeFeedback: PropTypes.bool,
       fixNativeFeedbackRadius: PropTypes.bool,
       nativeFeedbackRippleColor: PropTypes.string,
-      activeOpacity: PropTypes.number
+      activeOpacity: PropTypes.number,
+      numberOfLines: PropTypes.number,
     };
   }
 
@@ -140,7 +142,8 @@ export default class ActionButtonItem extends Component {
       parentSize,
       size,
       position,
-      spaceBetween
+      spaceBetween,
+      numberOfLines,
     } = this.props;
     const offsetTop = Math.max(size / 2 - TEXT_HEIGHT / 2, 0);
     const positionStyles = { top: offsetTop };
@@ -169,6 +172,7 @@ export default class ActionButtonItem extends Component {
         <Text
           allowFontScaling={false}
           style={[styles.text, this.props.textStyle]}
+          numberOfLines={numberOfLines}
         >
           {this.props.title}
         </Text>

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Take a look at [this gist](https://gist.github.com/mmazzarolo/cfd467436f9d110e94
 | textContainerStyle  | style   | null                | use this to set the textstyle of the button's item text container
 | textStyle     | style         | null                | use this to set the textstyle of the button's item text
 | spaceBetween  | number        | 15                  | use this to set the space between the Button and the text container
+| numberOfLines  | number        | 1                  | use this to set the number of lines on the button's item text
 | activeOpacity | number        | 0.85                | activeOpacity props of TouchableOpacity
 | hideLabelShadow | boolean     | same as hideShadow  | use this to hide the button's label default elevation and boxShadow
 | shadowStyle   | style         | null                | The custom shadow style you want to pass in the action button item


### PR DESCRIPTION
I found that when i set a fixed width on the action button items text container, the text would be chopped off abruptly. This prop allows the text to be displayed with an ellipsis. 