### PR TITLE
Set useNativeDriver to false explicitly in animation and reset

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -254,7 +254,7 @@ const ActionButton = props => {
     if (active) return reset(animate);
 
     if (animate) {
-      Animated.spring(anim.current, { toValue: 1 }).start();
+      Animated.spring(anim.current, { toValue: 1, useNativeDriver: false }).start();
     } else {
       anim.current.setValue(1);
     }
@@ -266,7 +266,7 @@ const ActionButton = props => {
     if (props.onReset) props.onReset();
 
     if (animate) {
-      Animated.spring(anim.current, { toValue: 0 }).start();
+      Animated.spring(anim.current, { toValue: 0, useNativeDriver: false }).start();
     } else {
       anim.current.setValue(0);
     }


### PR DESCRIPTION
#339  - Solution:
I believe that the proposal submitted earlier does not fully solve the problem presented in version 0.62 of the RN. Because it is necessary to insert useNativeDriver in the function that resets the action.
https://reactnative.dev/blog/2017/02/14/using-native-driver-for-animated#how-do-i-use-this-in-my-app