### PR TITLE
fix(ActionButton.js): improving filter to catch childrens of ActionButton

### DIFF
--- a/ActionButton.js
+++ b/ActionButton.js
@@ -202,7 +202,7 @@ const ActionButton = props => {
     let actionButtons = !Array.isArray(children) ? [children] : children;
 
     actionButtons = actionButtons.filter(
-      actionButton => typeof actionButton == "object"
+      actionButton => actionButton && typeof actionButton == "object"
     );
 
     const actionStyle = {


### PR DESCRIPTION
Improving filter because if children is rendering with a condition ex.:

```
{callcenter_phone ? (
        <ActionButton.Item
          onPress={handleOpenCall}
          buttonColor={childrenColor || theme.colors.primary}
        >
          <Icon name="phone" type="FontAwesome" />
        </ActionButton.Item>
) : null}
```

It pass in filter because typeof null is 'object'

This PR closes [issue 366](https://github.com/mastermoo/react-native-action-button/issues/366)